### PR TITLE
Migrated hotfixes for from_spec.. BaseNode methods

### DIFF
--- a/openmsimodel/entity/base/ingredient.py
+++ b/openmsimodel/entity/base/ingredient.py
@@ -50,12 +50,41 @@ class Ingredient(BaseNode):
         run: IngredientRun = None
         ) -> 'Process':
         '''
-        Instantiate a `Process` from a spec or run with appropriate validation.
+        Instantiate an `Ingredient` from a spec or run with appropriate validation.
 
         Note that the spec's template will be set to the class template,
         and the run's spec will be set to this spec.
         '''
-        pass
+        if spec is None and run is None:
+            raise ValueError('At least one of spec or run must be given.')
+
+        ingredient = cls(name, notes=notes)
+
+        if spec is not None:
+
+            if not isinstance(spec, IngredientSpec):
+                raise TypeError('spec must be a MeasurementSpec.')
+
+            ingredient._spec = spec
+
+            ingredient.spec.name = name
+            ingredient.spec.notes = notes
+
+        if run is not None:
+
+            if not isinstance(run, IngredientRun):
+                raise TypeError('run must be a MeasurementRun.')
+
+            ingredient._run = run
+
+            # ingredient._run.name = name
+            ingredient.run.notes = notes
+            ingredient.run.spec = ingredient.spec
+
+        else:
+            ingredient.run = make_instance(ingredient.spec)
+
+        return ingredient
         
 
     def to_form(self) -> str:

--- a/openmsimodel/entity/base/measurement.py
+++ b/openmsimodel/entity/base/measurement.py
@@ -89,7 +89,7 @@ class Measurement(ProcessOrMeasurement):
             if not isinstance(spec, MeasurementSpec):
                 raise TypeError("spec must be a MeasurementSpec.")
 
-            measurement.spec = spec
+            measurement._spec = spec
 
             measurement.spec.name = name
             measurement.spec.notes = notes
@@ -102,7 +102,7 @@ class Measurement(ProcessOrMeasurement):
             if not isinstance(run, MeasurementRun):
                 raise TypeError("run must be a MeasurementRun.")
 
-            measurement.run = run
+            measurement._run = run
 
             measurement.run.name = name
             measurement.run.notes = notes

--- a/openmsimodel/entity/base/process.py
+++ b/openmsimodel/entity/base/process.py
@@ -59,7 +59,7 @@ class Process(ProcessOrMeasurement):
                 raise TypeError('spec must be a ProcessSpec.')
             
             print(process.spec)
-            process.spec = spec
+            process._spec = spec
 
             process.spec.name = name
             process.spec.notes = notes
@@ -73,7 +73,7 @@ class Process(ProcessOrMeasurement):
             if not isinstance(run, ProcessRun):
                 raise TypeError('run must be a ProcessRun.')
 
-            process.run = run
+            process._run = run
 
             process.run.name = name
             process.run.notes = notes


### PR DESCRIPTION
Implemented hot-fixes for the `.from_spec_or_run` methods in `BaseNode` objects. Solutions may require refactoring depending on design choices regarding use of read-only class properties. The implementation of the `Ingredient.from_spec_or_run()` method is simplified and may need to be refactored to capture all data.